### PR TITLE
Various UI adjustments across all interface

### DIFF
--- a/App/Extensions/Presentation/View/TextExtensions.swift
+++ b/App/Extensions/Presentation/View/TextExtensions.swift
@@ -24,7 +24,7 @@ extension Text {
             .fontWeight(.semibold)
             .foregroundColor(.onBackground.opacity(opacity))
             .padding(.bottom, 25)
-            .padding([.leading, .trailing], 15)
+            .padding([.leading, .trailing], Spacing.medium)
     }
     
     func infoHeaderSmall() -> some View {

--- a/App/Extensions/Presentation/View/ViewExtensions.swift
+++ b/App/Extensions/Presentation/View/ViewExtensions.swift
@@ -35,9 +35,6 @@ extension View {
         padding(10)
             .background(Color.gray.opacity(0.3))
             .cornerRadius(10)
-            .padding(.top, 15)
-            .padding(.bottom, 10)
-            .padding(.horizontal, 15)
     }
     
     func getRect() -> CGRect {

--- a/App/Presentation/Styles/ButtonStyles/Bookmarks/CompactButtonStyle.swift
+++ b/App/Presentation/Styles/ButtonStyles/Bookmarks/CompactButtonStyle.swift
@@ -17,10 +17,9 @@ struct CompactButtonStyle: ButtonStyle {
     
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 100, maxHeight: 100, alignment: .center)
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
             .background(colored ? Color.surface : nil)
             .cornerRadius(15)
-            .padding(.bottom, 10)
             .scaleEffect(configuration.isPressed ? 0.9 : 1)
             .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
     }

--- a/App/Presentation/Styles/ButtonStyles/Bookmarks/ProgrammeCardStyle.swift
+++ b/App/Presentation/Styles/ButtonStyles/Bookmarks/ProgrammeCardStyle.swift
@@ -15,8 +15,6 @@ struct ProgrammeCardStyle: ButtonStyle {
             .frame(maxWidth: .infinity, minHeight: 120)
             .background(Color.surface)
             .cornerRadius(10)
-            .padding(.horizontal, 15)
-            .padding(.vertical, 10)
             .scaleEffect(configuration.isPressed ? 0.9 : 1)
             .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
     }

--- a/App/Presentation/Styles/ButtonStyles/ResourceBookingButtonStyle.swift
+++ b/App/Presentation/Styles/ButtonStyles/ResourceBookingButtonStyle.swift
@@ -11,10 +11,9 @@ import SwiftUI
 struct ResourceBookingButtonStyle: ButtonStyle {
     func makeBody(configuration: Self.Configuration) -> some View {
         configuration.label
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 120, maxHeight: 120, alignment: .center)
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
             .background(Color.surface)
             .cornerRadius(10)
-            .padding(.bottom, 10)
             .scaleEffect(configuration.isPressed ? 0.9 : 1)
             .animation(.easeOut(duration: 0.2), value: configuration.isPressed)
     }

--- a/App/Presentation/Styles/LabelStyles/ColorfulIconLabelStyle.swift
+++ b/App/Presentation/Styles/LabelStyles/ColorfulIconLabelStyle.swift
@@ -16,7 +16,7 @@ struct ColorfulIconLabelStyle: LabelStyle {
             configuration.title
                 .font(.system(size: 18, weight: .regular))
                 .foregroundColor(.onSurface)
-                .padding(.leading, 20)
+                .padding(.leading, Spacing.large)
         } icon: {
             configuration.icon
                 .font(.system(size: 16, weight: .semibold))
@@ -29,7 +29,7 @@ struct ColorfulIconLabelStyle: LabelStyle {
                         .foregroundColor(color)
                 )
         }
-        .padding(.leading, 10)
+        .padding(.leading, Spacing.small)
         .padding(.vertical, 2.5)
     }
 }

--- a/App/Presentation/Views/Account/Login/AccountLogin.swift
+++ b/App/Presentation/Views/Account/Login/AccountLogin.swift
@@ -45,7 +45,7 @@ struct AccountLogin: View {
                 Spacer()
             }
             .ignoresSafeArea(.keyboard)
-            .padding(.horizontal, 20)
+            .padding(.horizontal, Spacing.medium)
             .padding(.top, 35)
             .frame(alignment: .center)
         }

--- a/App/Presentation/Views/Account/Login/LoginHeader.swift
+++ b/App/Presentation/Views/Account/Login/LoginHeader.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LoginHeader: View {
     var body: some View {
-        VStack(alignment: .center, spacing: 10) {
+        VStack(alignment: .center, spacing: Spacing.small) {
             Text(NSLocalizedString("Log in", comment: ""))
                 .infoHeaderMedium()
             Text(NSLocalizedString("Please log in to continue", comment: ""))

--- a/App/Presentation/Views/Account/Login/LoginSubHeader.swift
+++ b/App/Presentation/Views/Account/Login/LoginSubHeader.swift
@@ -11,7 +11,7 @@ struct LoginSubHeader: View {
     let schoolName: String
     
     var body: some View {
-        VStack(spacing: 15) {
+        VStack(spacing: Spacing.medium) {
             Text(String(format: NSLocalizedString("Use your university credentials for %@ to sign in to your KronoX account", comment: ""), schoolName))
                 .font(.system(size: 16))
                 .foregroundColor(.onSurface.opacity(0.75))

--- a/App/Presentation/Views/Account/Login/PasswordField.swift
+++ b/App/Presentation/Views/Account/Login/PasswordField.swift
@@ -45,7 +45,7 @@ struct PasswordField: View {
             .buttonStyle(ScalingButtonStyle())
             Spacer()
         }
-        .padding(15)
+        .padding(Spacing.medium)
         .background(Color.surface)
         .cornerRadius(15)
     }

--- a/App/Presentation/Views/Account/Login/UsernameField.swift
+++ b/App/Presentation/Views/Account/Login/UsernameField.swift
@@ -23,9 +23,9 @@ struct UsernameField: View {
                 .keyboardType(.emailAddress)
             Spacer()
         }
-        .padding(15)
+        .padding(Spacing.medium)
         .background(Color.surface)
         .cornerRadius(15)
-        .padding(.bottom, 10)
+        .padding(.bottom, Spacing.small)
     }
 }

--- a/App/Presentation/Views/Account/User/ProfileSection/UserOverview.swift
+++ b/App/Presentation/Views/Account/User/ProfileSection/UserOverview.swift
@@ -14,7 +14,7 @@ struct UserOverview: View {
     @State private var collapsedHeader: Bool = false
     
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             HStack {
                 if let name = viewModel.userDisplayName,
                    let username = viewModel.username
@@ -39,7 +39,7 @@ struct UserOverview: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             Divider()
                 .foregroundColor(.onBackground)
-                .padding(.horizontal, 15)
+                .padding(.top, 15)
             Resources(
                 parentViewModel: viewModel,
                 getResourcesAndEvents: getResourcesAndEvents,

--- a/App/Presentation/Views/Account/User/ProfileSection/UserOverview.swift
+++ b/App/Presentation/Views/Account/User/ProfileSection/UserOverview.swift
@@ -29,17 +29,17 @@ struct UserOverview: View {
                                 .font(.system(size: 16, weight: .regular))
                             Text(viewModel.schoolName)
                                 .font(.system(size: 14, weight: .semibold))
-                                .padding(.top, 10)
+                                .padding(.top, Spacing.small)
                         }
                     }
-                    .padding(10)
+                    .padding(Spacing.small)
                 }
             }
-            .padding(.horizontal, 15)
+            .padding(.horizontal, Spacing.medium)
             .frame(maxWidth: .infinity, alignment: .leading)
             Divider()
                 .foregroundColor(.onBackground)
-                .padding(.top, 15)
+                .padding(.top, Spacing.medium)
             Resources(
                 parentViewModel: viewModel,
                 getResourcesAndEvents: getResourcesAndEvents,

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/EventBookings.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/EventBookings.swift
@@ -21,37 +21,39 @@ struct EventBookings: View {
                         .frame(width: geo.size.width)
                         .frame(minHeight: geo.size.height)
                 case .loaded:
-                    SectionDivider(title: NSLocalizedString("Registered", comment: ""), image: "person.crop.circle.badge.checkmark", content: {
-                        if (viewModel.completeUserEvent?.registeredEvents) != nil {
-                            Events(registeredEvents: viewModel.completeUserEvent?.registeredEvents, onTapEventAction: { eventId, eventType in
-                                onTapEventAction(eventId: eventId, eventType: eventType)
-                            })
-                        } else {
-                            Text(NSLocalizedString("No registered events available", comment: ""))
-                                .sectionDividerEmpty()
-                                .padding(.top, 5)
-                        }
-                    })
-                    SectionDivider(title: NSLocalizedString("Unregistered", comment: ""), image: "person.crop.circle.badge.xmark", content: {
-                        if viewModel.completeUserEvent?.unregisteredEvents != nil {
-                            Events(unregisteredEvents: viewModel.completeUserEvent?.unregisteredEvents, onTapEventAction: { eventId, eventType in
-                                onTapEventAction(eventId: eventId, eventType: eventType)
-                            })
-                        } else {
-                            Text(NSLocalizedString("No unregistered events available", comment: ""))
-                                .sectionDividerEmpty()
-                                .padding(.top, 5)
-                        }
-                    })
-                    SectionDivider(title: NSLocalizedString("Upcoming", comment: ""), image: "person.crop.circle.badge.clock", content: {
-                        if viewModel.completeUserEvent?.upcomingEvents != nil {
-                            Events(upcomingEvents: viewModel.completeUserEvent?.upcomingEvents)
-                        } else {
-                            Text(NSLocalizedString("No upcoming events available", comment: ""))
-                                .sectionDividerEmpty()
-                                .padding(.top, 5)
-                        }
-                    })
+                    VStack(spacing: Spacing.large) {
+                        SectionDivider(title: NSLocalizedString("Registered", comment: ""), image: "person.crop.circle.badge.checkmark", content: {
+                            if (viewModel.completeUserEvent?.registeredEvents) != nil {
+                                Events(registeredEvents: viewModel.completeUserEvent?.registeredEvents, onTapEventAction: { eventId, eventType in
+                                    onTapEventAction(eventId: eventId, eventType: eventType)
+                                })
+                            } else {
+                                Text(NSLocalizedString("No registered events available", comment: ""))
+                                    .sectionDividerEmpty()
+                                    .padding(.top, 5)
+                            }
+                        })
+                        SectionDivider(title: NSLocalizedString("Unregistered", comment: ""), image: "person.crop.circle.badge.xmark", content: {
+                            if viewModel.completeUserEvent?.unregisteredEvents != nil {
+                                Events(unregisteredEvents: viewModel.completeUserEvent?.unregisteredEvents, onTapEventAction: { eventId, eventType in
+                                    onTapEventAction(eventId: eventId, eventType: eventType)
+                                })
+                            } else {
+                                Text(NSLocalizedString("No unregistered events available", comment: ""))
+                                    .sectionDividerEmpty()
+                                    .padding(.top, 5)
+                            }
+                        })
+                        SectionDivider(title: NSLocalizedString("Upcoming", comment: ""), image: "person.crop.circle.badge.clock", content: {
+                            if viewModel.completeUserEvent?.upcomingEvents != nil {
+                                Events(upcomingEvents: viewModel.completeUserEvent?.upcomingEvents)
+                            } else {
+                                Text(NSLocalizedString("No upcoming events available", comment: ""))
+                                    .sectionDividerEmpty()
+                                    .padding(.top, 5)
+                            }
+                        })
+                    }
                 case .error:
                     Info(title: NSLocalizedString("Could not contact the server, try again later", comment: ""), image: nil)
                         .frame(width: geo.size.width)

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/EventCardButton.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/EventCardButton.swift
@@ -18,9 +18,9 @@ struct EventCardButton: View {
     let onTap: (String, EventType) -> Void
     
     var body: some View {
-        VStack {
+        VStack(spacing: Spacing.small) {
             HStack {
-                VStack(alignment: .leading, spacing: 10) {
+                VStack(alignment: .leading, spacing: Spacing.small) {
                     HStack {
                         Text(event.title ?? NSLocalizedString("No title", comment: ""))
                             .font(.system(size: 17, weight: .medium))
@@ -63,8 +63,8 @@ struct EventCardButton: View {
                 }
                 Spacer()
             }
-            .padding()
-            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 100, maxHeight: 100, alignment: .center)
+            .padding(Spacing.card)
+            .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
             .background(Color.surface)
             .cornerRadius(15)
             if event.lastSignupDate.isValidRegistrationDate() {
@@ -83,13 +83,12 @@ struct EventCardButton: View {
                                 .font(.system(size: 16, weight: .semibold))
                                 .foregroundColor(.onPrimary)
                         }
-                        .padding(10)
+                        .padding(Spacing.small)
                         .background(Color.primary)
                         .cornerRadius(10)
                     })
                 }
             }
         }
-        .padding(.bottom, 10)
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/Events.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/Events.swift
@@ -34,7 +34,7 @@ struct Events: View {
     var registeredEventsView: some View {
         VStack {
             if let events = registeredEvents, let onTapEventAction = onTapEventAction {
-                VStack(alignment: .leading, spacing: 15) {
+                VStack(alignment: .leading, spacing: 5) {
                     ForEach(events, id: \.id) { event in
                         EventCardButton(event: event, eventType: .unregister, onTap: onTapEventAction)
                     }
@@ -68,7 +68,7 @@ struct Events: View {
     var upcomingEventsView: some View {
         VStack {
             if let upcomingEvents = upcomingEvents {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: 15) {
                     ForEach(upcomingEvents, id: \.id) { event in
                         UpcomingEventCardButton(event: event)
                     }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/Events.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/Events.swift
@@ -34,7 +34,7 @@ struct Events: View {
     var registeredEventsView: some View {
         VStack {
             if let events = registeredEvents, let onTapEventAction = onTapEventAction {
-                VStack(alignment: .leading, spacing: 5) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
                     ForEach(events, id: \.id) { event in
                         EventCardButton(event: event, eventType: .unregister, onTap: onTapEventAction)
                     }
@@ -51,7 +51,7 @@ struct Events: View {
     var unregisteredEventsView: some View {
         VStack {
             if let events = unregisteredEvents, let onTapEventAction = onTapEventAction {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
                     ForEach(events, id: \.id) { event in
                         EventCardButton(event: event, eventType: .register, onTap: onTapEventAction)
                     }
@@ -68,7 +68,7 @@ struct Events: View {
     var upcomingEventsView: some View {
         VStack {
             if let upcomingEvents = upcomingEvents {
-                VStack(alignment: .leading, spacing: 15) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
                     ForEach(upcomingEvents, id: \.id) { event in
                         UpcomingEventCardButton(event: event)
                     }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/UpcomingEventCardButton.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Events/UpcomingEventCardButton.swift
@@ -49,9 +49,9 @@ struct UpcomingEventCardButton: View {
             }
             Spacer()
         }
-        .padding()
-        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 100, maxHeight: 100, alignment: .center)
+        .padding(Spacing.card)
+        .frame(minWidth: 0, maxWidth: .infinity, alignment: .center)
         .background(Color.surface)
-        .cornerRadius(20)
+        .cornerRadius(15)
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceBookings.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceBookings.swift
@@ -14,40 +14,42 @@ struct ResourceBookings: View {
     var body: some View {
         VStack {
             ScrollView(showsIndicators: false) {
-                ResourceDatePicker(date: $viewModel.selectedPickerDate)
-                Divider()
-                    .foregroundColor(.onBackground)
-                switch viewModel.resourceBookingPageState {
-                case .loading:
-                    VStack {
-                        CustomProgressIndicator()
-                    }
-                    .frame(
-                        maxWidth: .infinity,
-                        minHeight: 200,
-                        maxHeight: .infinity,
-                        alignment: .center
-                    )
-                case .loaded:
-                    ResourceLocationsList(
-                        parentViewModel: viewModel,
-                        selectedPickerDate: $viewModel.selectedPickerDate,
-                        updateBookingNotifications: updateBookingNotifications
-                    )
-                case .error:
-                    VStack {
-                        if isWeekend(on: viewModel.selectedPickerDate) {
-                            Info(title: NSLocalizedString("No rooms available on weekends", comment: ""), image: "moon.zzz")
-                        } else {
-                            Info(title: NSLocalizedString("Could not contact the server, try again later", comment: ""), image: "arrow.clockwise")
+                VStack(spacing: Spacing.medium) {
+                    ResourceDatePicker(date: $viewModel.selectedPickerDate)
+                    Divider()
+                        .foregroundColor(.onBackground)
+                    switch viewModel.resourceBookingPageState {
+                    case .loading:
+                        VStack {
+                            CustomProgressIndicator()
                         }
+                        .frame(
+                            maxWidth: .infinity,
+                            minHeight: 200,
+                            maxHeight: .infinity,
+                            alignment: .center
+                        )
+                    case .loaded:
+                        ResourceLocationsList(
+                            parentViewModel: viewModel,
+                            selectedPickerDate: $viewModel.selectedPickerDate,
+                            updateBookingNotifications: updateBookingNotifications
+                        )
+                    case .error:
+                        VStack {
+                            if isWeekend(on: viewModel.selectedPickerDate) {
+                                Info(title: NSLocalizedString("No rooms available on weekends", comment: ""), image: "moon.zzz")
+                            } else {
+                                Info(title: NSLocalizedString("Could not contact the server, try again later", comment: ""), image: "arrow.clockwise")
+                            }
+                        }
+                        .frame(
+                            maxWidth: .infinity,
+                            minHeight: 200,
+                            maxHeight: .infinity,
+                            alignment: .center
+                        )
                     }
-                    .frame(
-                        maxWidth: .infinity,
-                        minHeight: 200,
-                        maxHeight: .infinity,
-                        alignment: .center
-                    )
                 }
             }
         }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceDatePicker.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceDatePicker.swift
@@ -18,7 +18,7 @@ struct ResourceDatePicker: View {
             displayedComponents: [.date]
         )
         .frame(minHeight: 300)
-        .padding(.horizontal, 15)
+        .padding(.horizontal, Spacing.medium)
         .datePickerStyle(.graphical)
         .accentColor(Color.primary)
         .background(Color.background)

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceLocationsList.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceLocationsList.swift
@@ -65,6 +65,6 @@ struct ResourceLocationsList: View {
                 .padding(.horizontal)
             }
         }
-        .padding(.top)
+        .padding(.top, 7.5)
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceLocationsList.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceLocationsList.swift
@@ -16,7 +16,7 @@ struct ResourceLocationsList: View {
     var body: some View {
         /// List of all available buildings that
         /// allow for booking rooms
-        VStack {
+        VStack(spacing: Spacing.medium) {
             ForEach(parentViewModel.allResources!, id: \.self.id) { resource in
                 let availableCounts = resource.availabilities.countAvailable()
                 NavigationLink(destination: {
@@ -30,7 +30,7 @@ struct ResourceLocationsList: View {
                     .navigationBarTitleDisplayMode(.inline)
                 }, label: {
                     HStack(spacing: 0) {
-                        VStack(alignment: .leading, spacing: 10) {
+                        VStack(alignment: .leading, spacing: Spacing.small) {
                             HStack {
                                 Text(resource.name ?? NSLocalizedString("No name", comment: ""))
                                     .font(.system(size: 18, weight: .medium))
@@ -56,15 +56,14 @@ struct ResourceLocationsList: View {
                                     .foregroundColor(.onSurface.opacity(0.7))
                             }
                         }
-                        .padding()
+                        .padding(Spacing.card)
                         Spacer()
                     }
                 })
                 .disabled(!(availableCounts > 0))
                 .buttonStyle(ResourceBookingButtonStyle())
-                .padding(.horizontal)
+                .padding(.horizontal, Spacing.medium)
             }
         }
-        .padding(.top, 7.5)
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceSelection.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceSelection.swift
@@ -20,7 +20,7 @@ struct ResourceSelection: View {
     
     var body: some View {
         if let timeslots = resource.timeSlots {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text(selectedPickerDate.formatDate())
                     .font(.system(size: 22, weight: .semibold))
                     .foregroundColor(.onBackground)

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceSelection.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceSelection.swift
@@ -24,8 +24,8 @@ struct ResourceSelection: View {
                 Text(selectedPickerDate.formatDate())
                     .font(.system(size: 22, weight: .semibold))
                     .foregroundColor(.onBackground)
-                    .padding(.horizontal, 15)
-                    .padding(.vertical, 20)
+                    .padding(.horizontal, Spacing.medium)
+                    .padding(.vertical, Spacing.large)
                 TimeslotDropdown(
                     resource: resource,
                     timeslots: timeslots,

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceTimeDropdown.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceTimeDropdown.swift
@@ -27,14 +27,14 @@ struct TimeslotDropdown: View {
                     .foregroundColor(.onSurface)
                     .rotationEffect(isSelecting ? .degrees(180) : .zero)
             }
-            .padding(.horizontal, 15)
+            .padding(.horizontal, Spacing.medium)
             if isSelecting {
                 Divider()
                     .background(.white)
                     .padding(.horizontal)
-                    .padding(.bottom, 10)
+                    .padding(.bottom, Spacing.small)
 
-                VStack(spacing: 30) {
+                VStack(spacing: Spacing.medium * 2) {
                     ForEach(Array(timeslots.enumerated()), id: \.offset) { index, timeslot in
                         if let timeslotId = timeslot.id,
                            resource.availabilities.timeslotHasAvailable(for: timeslotId),
@@ -54,7 +54,7 @@ struct TimeslotDropdown: View {
                         }
                     }
                 }
-                .padding(.vertical, 10)
+                .padding(.vertical, Spacing.small)
             }
         }
         .onAppear {
@@ -68,8 +68,8 @@ struct TimeslotDropdown: View {
         .padding(.vertical)
         .background(Color.surface)
         .cornerRadius(10)
-        .padding(.horizontal, 15)
-        .padding(.bottom, 15)
+        .padding(.horizontal, Spacing.medium)
+        .padding(.bottom, Spacing.medium)
         .onTapGesture {
             withAnimation(.easeInOut) {
                 isSelecting.toggle()

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceTimeDropdown.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/ResourceTimeDropdown.swift
@@ -25,14 +25,16 @@ struct TimeslotDropdown: View {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundColor(.onSurface)
+                    .rotationEffect(isSelecting ? .degrees(180) : .zero)
             }
             .padding(.horizontal, 15)
             if isSelecting {
                 Divider()
                     .background(.white)
                     .padding(.horizontal)
+                    .padding(.bottom, 10)
 
-                VStack(spacing: 5) {
+                VStack(spacing: 30) {
                     ForEach(Array(timeslots.enumerated()), id: \.offset) { index, timeslot in
                         if let timeslotId = timeslot.id,
                            resource.availabilities.timeslotHasAvailable(for: timeslotId),
@@ -52,6 +54,7 @@ struct TimeslotDropdown: View {
                         }
                     }
                 }
+                .padding(.vertical, 10)
             }
         }
         .onAppear {
@@ -107,7 +110,7 @@ private struct DropdownMenuItemView: View {
                         .foregroundColor(.onSurface)
                 }
             }
-            .padding()
+            .padding(.horizontal)
             .foregroundColor(.onBackground)
         }
     }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotCard.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotCard.swift
@@ -46,7 +46,5 @@ struct TimeslotCard: View {
         .frame(maxWidth: .infinity, maxHeight: 70)
         .background(Color.surface)
         .cornerRadius(10)
-        .padding(.horizontal, 15)
-        .padding(.vertical, 10)
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotCard.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotCard.swift
@@ -31,18 +31,18 @@ struct TimeslotCard: View {
                     Text(NSLocalizedString("Booked", comment: ""))
                         .font(.system(size: 18, weight: .semibold))
                         .foregroundColor(.onPrimary)
-                        .padding(7.5)
+                        .padding(Spacing.medium / 2)
                 case .available:
                     Text(NSLocalizedString("Book", comment: ""))
                         .font(.system(size: 18, weight: .semibold))
                         .foregroundColor(.onPrimary)
-                        .padding(7.5)
+                        .padding(Spacing.medium / 2)
                 }
             })
             .disabled(bookingButtonState == .booked)
             .buttonStyle(BookButtonStyle())
         }
-        .padding()
+        .padding(Spacing.medium)
         .frame(maxWidth: .infinity, maxHeight: 70)
         .background(Color.surface)
         .cornerRadius(10)

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotSelection.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotSelection.swift
@@ -43,17 +43,20 @@ struct TimeslotSelection: View {
             }.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         } else {
             ScrollView(showsIndicators: false) {
-                ForEach(availabilityValues, id: \.self) { availabilityValue in
-                    if let locationId = availabilityValue.locationID {
-                        TimeslotCard(
-                            onBook: { handleBooking(for: locationId, with: availabilityValue) },
-                            locationId: locationId,
-                            bookingButtonState: Binding(
-                            get: { buttonStateMap[locationId] ?? .available },
-                            set: { buttonStateMap[locationId] = $0 }
-                        ))
+                VStack(spacing: 15) {
+                    ForEach(availabilityValues, id: \.self) { availabilityValue in
+                        if let locationId = availabilityValue.locationID {
+                            TimeslotCard(
+                                onBook: { handleBooking(for: locationId, with: availabilityValue) },
+                                locationId: locationId,
+                                bookingButtonState: Binding(
+                                    get: { buttonStateMap[locationId] ?? .available },
+                                    set: { buttonStateMap[locationId] = $0 }
+                                ))
+                        }
                     }
                 }
+                .padding(15)
             }
         }
     }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotSelection.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Resources/TimeslotSelection.swift
@@ -43,7 +43,7 @@ struct TimeslotSelection: View {
             }.frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
         } else {
             ScrollView(showsIndicators: false) {
-                VStack(spacing: 15) {
+                VStack(spacing: Spacing.medium) {
                     ForEach(availabilityValues, id: \.self) { availabilityValue in
                         if let locationId = availabilityValue.locationID {
                             TimeslotCard(
@@ -56,7 +56,7 @@ struct TimeslotSelection: View {
                         }
                     }
                 }
-                .padding(15)
+                .padding(Spacing.medium)
             }
         }
     }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/SectionDivider.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/SectionDivider.swift
@@ -36,6 +36,6 @@ struct SectionDivider<Content: View>: View {
             .padding(.bottom)
             content
         }
-        .padding(25)
+        .padding(Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Sheets/ExamDetailsSheet.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Sheets/ExamDetailsSheet.swift
@@ -55,8 +55,8 @@ struct ExamDetailsSheet: View {
                     }
                 })
                 .buttonStyle(WideAnimatedButtonStyle(color: .red))
-                .padding(.horizontal, 15)
-                .padding(.top, 20)
+                .padding(.horizontal, Spacing.medium)
+                .padding(.top, Spacing.large)
                 .alert(isPresented: $showingUnregisterConfirmationDialog) {
                     Alert(
                         title: Text(NSLocalizedString("Confirm Unregistration", comment: "")),
@@ -72,7 +72,7 @@ struct ExamDetailsSheet: View {
                 }
             }
         }
-        .padding(.top, 55)
+        .padding(.top, Spacing.header)
         .background(Color.background)
         .overlay(
             CloseCoverButton(onClick: {

--- a/App/Presentation/Views/Account/User/ResourceSection/Booking/Sheets/ResourceDetailSheet.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Booking/Sheets/ResourceDetailSheet.swift
@@ -16,7 +16,7 @@ struct ResourceDetailSheet: View {
     @Environment(\.dismiss) var dismiss
     
     var body: some View {
-        VStack {
+        VStack(spacing: Spacing.medium) {
             DetailsBuilder(title: NSLocalizedString("Location", comment: ""), image: "mappin.and.ellipse", content: {
                 Text(resource.locationID)
                     .font(.system(size: 16))
@@ -54,8 +54,8 @@ struct ResourceDetailSheet: View {
                     }
                 })
                 .buttonStyle(WideAnimatedButtonStyle())
-                .padding(.horizontal, 15)
-                .padding(.top, 20)
+                .padding(.horizontal, Spacing.medium)
+                .padding(.top, Spacing.large)
             }
             if resource.showUnbookButton {
                 Button(action: {
@@ -70,11 +70,11 @@ struct ResourceDetailSheet: View {
                     }
                 })
                 .buttonStyle(WideAnimatedButtonStyle(color: .red))
-                .padding(.horizontal, 15)
-                .padding(.top, 20)
+                .padding(.horizontal, Spacing.medium)
+                .padding(.top, Spacing.large)
             }
         }
-        .padding(.top, 55)
+        .padding(.top, Spacing.header)
         .background(Color.background)
         .overlay(
             CloseCoverButton(onClick: {

--- a/App/Presentation/Views/Account/User/ResourceSection/RegisteredBookings.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/RegisteredBookings.swift
@@ -22,17 +22,19 @@ struct RegisteredBookings: View {
             case .loaded:
                 if let bookings = bookings {
                     if !bookings.isEmpty {
-                        ForEach(bookings) { resource in
-                            ResourceCard(
-                                eventStart: resource.timeSlot.from?.convertToHoursAndMinutes() ?? NSLocalizedString("(no time)", comment: ""),
-                                eventEnd: resource.timeSlot.to?.convertToHoursAndMinutes() ?? NSLocalizedString("(no time)", comment: ""),
-                                title: NSLocalizedString("Booked resource", comment: ""),
-                                location: resource.locationID,
-                                date: resource.timeSlot.from?.toDate() ?? NSLocalizedString("(no date)", comment: ""),
-                                onClick: {
-                                    onClickResource(resource)
-                                }
-                            )
+                        VStack(spacing: Spacing.medium) {
+                            ForEach(bookings) { resource in
+                                ResourceCard(
+                                    eventStart: resource.timeSlot.from?.convertToHoursAndMinutes() ?? NSLocalizedString("(no time)", comment: ""),
+                                    eventEnd: resource.timeSlot.to?.convertToHoursAndMinutes() ?? NSLocalizedString("(no time)", comment: ""),
+                                    title: NSLocalizedString("Booked resource", comment: ""),
+                                    location: resource.locationID,
+                                    date: resource.timeSlot.from?.toDate() ?? NSLocalizedString("(no date)", comment: ""),
+                                    onClick: {
+                                        onClickResource(resource)
+                                    }
+                                )
+                            }
                         }
                     } else {
                         Text(NSLocalizedString("No booked resources yet", comment: ""))

--- a/App/Presentation/Views/Account/User/ResourceSection/RegisteredEvents.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/RegisteredEvents.swift
@@ -22,20 +22,22 @@ struct RegisteredEvents: View {
             case .loaded:
                 if let events = registeredEvents {
                     if !events.isEmpty {
-                        ForEach(events) { event in
-                            if let eventStart = event.eventStart.convertToHoursAndMinutes(),
-                               let eventEnd = event.eventEnd.convertToHoursAndMinutes()
-                            {
-                                ResourceCard(
-                                    eventStart: eventStart,
-                                    eventEnd: eventEnd,
-                                    type: event.type,
-                                    title: event.title,
-                                    date: event.eventStart.toDate() ?? NSLocalizedString("(no date)", comment: ""),
-                                    onClick: {
-                                        onClickEvent(event)
-                                    }
-                                )
+                        VStack(spacing: Spacing.medium) {
+                            ForEach(events) { event in
+                                if let eventStart = event.eventStart.convertToHoursAndMinutes(),
+                                   let eventEnd = event.eventEnd.convertToHoursAndMinutes()
+                                {
+                                    ResourceCard(
+                                        eventStart: eventStart,
+                                        eventEnd: eventEnd,
+                                        type: event.type,
+                                        title: event.title,
+                                        date: event.eventStart.toDate() ?? NSLocalizedString("(no date)", comment: ""),
+                                        onClick: {
+                                            onClickEvent(event)
+                                        }
+                                    )
+                                }
                             }
                         }
                     } else {

--- a/App/Presentation/Views/Account/User/ResourceSection/ResourceCard.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/ResourceCard.swift
@@ -56,7 +56,6 @@ struct ResourceCard: View {
                 Spacer()
             }
         })
-        .padding(.top)
         .buttonStyle(CompactButtonStyle(colored: true))
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/ResourceCard.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/ResourceCard.swift
@@ -40,7 +40,7 @@ struct ResourceCard: View {
             onClick()
         }, label: {
             HStack {
-                VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: Spacing.small) {
                     TitleView(title: title)
                     
                     if let type = type {
@@ -52,7 +52,7 @@ struct ResourceCard: View {
                     
                     DateView(date: date, start: eventStart, end: eventEnd)
                 }
-                .padding()
+                .padding(Spacing.card)
                 Spacer()
             }
         })
@@ -77,16 +77,13 @@ struct InformationView: View {
     let text: String
     
     var body: some View {
-        VStack (spacing: 0) {
-            Spacer()
-            HStack (alignment: .top) {
-                Image(systemName: imageName)
-                    .font(.system(size: 15))
-                    .foregroundColor(.onSurface.opacity(0.7))
-                Text(text)
-                    .font(.system(size: 15))
-                    .foregroundColor(.onSurface.opacity(0.7))
-            }
+        HStack (alignment: .center) {
+            Image(systemName: imageName)
+                .font(.system(size: 15))
+                .foregroundColor(.onSurface.opacity(0.7))
+            Text(text.trimmingCharacters(in: .whitespacesAndNewlines))
+                .font(.system(size: 15))
+                .foregroundColor(.onSurface.opacity(0.7))
         }
     }
 }
@@ -97,16 +94,13 @@ struct DateView: View {
     let end: String
     
     var body: some View {
-        VStack (spacing: 0) {
-            Spacer()
-            HStack (alignment: .top) {
-                Image(systemName: "calendar.badge.clock")
-                    .font(.system(size: 15))
-                    .foregroundColor(.onSurface.opacity(0.7))
-                Text(String(format: NSLocalizedString("%@, from %@ to %@", comment: ""), date, start, end))
-                    .font(.system(size: 15))
-                    .foregroundColor(.onSurface.opacity(0.7))
-            }
+        HStack (alignment: .center) {
+            Image(systemName: "calendar.badge.clock")
+                .font(.system(size: 15))
+                .foregroundColor(.onSurface.opacity(0.7))
+            Text(String(format: NSLocalizedString("%@, from %@ to %@", comment: ""), date, start, end))
+                .font(.system(size: 15))
+                .foregroundColor(.onSurface.opacity(0.7))
         }
     }
 }

--- a/App/Presentation/Views/Account/User/ResourceSection/ResourceSectionDivider.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/ResourceSectionDivider.swift
@@ -53,11 +53,11 @@ struct ResourceSectionDivider<Content: View>: View {
                     })
                 }
             }
-            .padding(.bottom, 10)
+            .padding(.bottom, Spacing.small)
             content
         }
-        .padding(.vertical, 7.5)
-        .padding(.horizontal, 17)
+        .padding(.vertical, Spacing.medium / 2)
+        .padding(.horizontal, Spacing.medium)
     }
 }
 

--- a/App/Presentation/Views/Account/User/ResourceSection/Resources.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Resources.swift
@@ -34,6 +34,7 @@ struct Resources: View {
                 VStack {
                     PullToRefreshIndicator()
                         .padding(.bottom, -15)
+                        .padding(.top, 10)
                     ResourceSectionDivider(title: NSLocalizedString("User options", comment: "")) {
                         Toggle(isOn: $parentViewModel.autoSignupEnabled) {
                             Text(NSLocalizedString("Automatic exam signup", comment: ""))

--- a/App/Presentation/Views/Account/User/ResourceSection/Resources.swift
+++ b/App/Presentation/Views/Account/User/ResourceSection/Resources.swift
@@ -34,7 +34,7 @@ struct Resources: View {
                 VStack {
                     PullToRefreshIndicator()
                         .padding(.bottom, -15)
-                        .padding(.top, 10)
+                        .padding(.top, Spacing.small)
                     ResourceSectionDivider(title: NSLocalizedString("User options", comment: "")) {
                         Toggle(isOn: $parentViewModel.autoSignupEnabled) {
                             Text(NSLocalizedString("Automatic exam signup", comment: ""))
@@ -74,8 +74,8 @@ struct Resources: View {
                                                    }
                                                )
                                                .navigationTitle(NSLocalizedString("Resources", comment: ""))
-                                               .navigationBarTitleDisplayMode(.inline)
-                                           )) {
+                                               .navigationBarTitleDisplayMode(.inline)))
+                    {
                         RegisteredBookings(
                             onClickResource: onClickResource,
                             state: $parentViewModel.bookingSectionState,

--- a/App/Presentation/Views/Bookmarks/Bookmarks.swift
+++ b/App/Presentation/Views/Bookmarks/Bookmarks.swift
@@ -43,7 +43,7 @@ struct Bookmarks: View {
                         }
                         .tabViewStyle(.page(indexDisplayMode: .never))
                         ViewSwitcher(parentViewModel: viewModel)
-                            .padding(.bottom, 15)
+                            .padding(.bottom, Spacing.medium)
                     }
                 case .uninitialized:
                     Info(title: NSLocalizedString("No bookmarks yet", comment: ""), image: "bookmark.slash")

--- a/App/Presentation/Views/Bookmarks/Bookmarks.swift
+++ b/App/Presentation/Views/Bookmarks/Bookmarks.swift
@@ -21,7 +21,7 @@ struct Bookmarks: View {
                     CustomProgressIndicator()
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                 case .loaded:
-                    ZStack (alignment: .top) {
+                    ZStack (alignment: .bottom) {
                         TabView (selection: $viewModel.defaultViewType) {
                             BookmarkListView(
                                 days: viewModel.bookmarkData.days,
@@ -43,7 +43,7 @@ struct Bookmarks: View {
                         }
                         .tabViewStyle(.page(indexDisplayMode: .never))
                         ViewSwitcher(parentViewModel: viewModel)
-                            .padding(.top, 5)
+                            .padding(.bottom, 15)
                     }
                 case .uninitialized:
                     Info(title: NSLocalizedString("No bookmarks yet", comment: ""), image: "bookmark.slash")

--- a/App/Presentation/Views/Bookmarks/Calendar/BookmarkCalendarDetail.swift
+++ b/App/Presentation/Views/Bookmarks/Calendar/BookmarkCalendarDetail.swift
@@ -21,6 +21,6 @@ struct BookmarkCalendarDetail: View {
             }
         })
         .buttonStyle(CompactButtonStyle())
-        .padding(.horizontal, 15)
+        .padding(.horizontal, Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Bookmarks/Calendar/BookmarkCalendarView.swift
+++ b/App/Presentation/Views/Bookmarks/Calendar/BookmarkCalendarView.swift
@@ -19,8 +19,6 @@ struct BookmarkCalendarView: View {
     
     var body: some View {
         ScrollView(showsIndicators: false) {
-            Spacer()
-                .frame(height: 60)
             CalendarViewRepresentable(
                 selectedDate: $selectedDate,
                 selectedDateEvents: $selectedDateEvents,

--- a/App/Presentation/Views/Bookmarks/Calendar/BookmarkCalendarView.swift
+++ b/App/Presentation/Views/Bookmarks/Calendar/BookmarkCalendarView.swift
@@ -36,14 +36,16 @@ struct BookmarkCalendarView: View {
             VStack {
                 if selectedDateEvents.isEmpty {
                     HStack {
+                        Spacer()
                         Text(NSLocalizedString("No events for this date", comment: ""))
                             .foregroundColor(.onBackground)
                             .font(.system(size: 20, weight: .semibold))
                         Spacer()
                     }
-                    .padding([.top, .leading], 15)
+                    .padding(.top, Spacing.extraLarge)
+                    .padding(.horizontal, Spacing.medium)
                 } else {
-                    VStack {
+                    VStack(spacing: Spacing.medium) {
                         ForEach(selectedDateEvents.sorted(), id: \.self) { event in
                             BookmarkCalendarDetail(
                                 onTapDetail: onTapDetail,
@@ -51,8 +53,8 @@ struct BookmarkCalendarView: View {
                             )
                         }
                     }
-                    .padding(.vertical, 20)
-                }
+                    .padding(.vertical, Spacing.large)
+               }
             }
         }
         .onFirstAppear {

--- a/App/Presentation/Views/Bookmarks/EventDetails/DetailsBuilder.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/DetailsBuilder.swift
@@ -20,8 +20,8 @@ struct DetailsBuilder<Content: View>: View {
     
     var body: some View {
         HStack {
-            VStack(alignment: .leading, spacing: 0) {
-                HStack(alignment: .center, spacing: 10) {
+            VStack(alignment: .leading, spacing: Spacing.card) {
+                HStack(alignment: .center, spacing: Spacing.small) {
                     Image(systemName: image)
                         .font(.system(size: 17))
                         .foregroundColor(.onSurface)
@@ -30,18 +30,15 @@ struct DetailsBuilder<Content: View>: View {
                         .bold()
                         .foregroundColor(.onBackground)
                 }
-                .padding(.bottom, 5)
                 VStack(alignment: .leading) {
                     content
                 }
-                .padding(.top, 7.5)
             }
             Spacer()
         }
-        .padding(15)
+        .padding(Spacing.card)
         .background(Color.surface)
         .cornerRadius(15)
-        .padding(.top, 10)
-        .padding(.horizontal, 15)
+        .padding(.horizontal, Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsBody.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsBody.swift
@@ -14,7 +14,7 @@ struct EventDetailsBody: View {
     @State private var locationSheetOpen = false
     
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
             DetailsBuilder(title: NSLocalizedString("Course", comment: ""), image: "text.book.closed") {
                 Text(event.course?.englishName ?? "")
                     .font(.system(size: 16))

--- a/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsBody.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsBody.swift
@@ -24,9 +24,11 @@ struct EventDetailsBody: View {
                 if !event.teachers.isEmpty {
                     if !event.teachers.first!.firstName.isEmpty && !event.teachers.first!.lastName.isEmpty {
                         ForEach(event.teachers, id: \.self) { teacher in
-                            Text("\(teacher.firstName) \(teacher.lastName)")
-                                .font(.system(size: 16))
-                                .foregroundColor(.onSurface)
+                            if !teacher.firstName.isEmpty {
+                                Text("\(teacher.firstName) \(teacher.lastName)")
+                                    .font(.system(size: 16))
+                                    .foregroundColor(.onSurface)
+                            }
                         }
                     } else {
                         Text(NSLocalizedString("No teachers listed at this time", comment: ""))
@@ -61,7 +63,7 @@ struct EventDetailsBody: View {
                         }
                         Spacer()
                         Image(systemName: "chevron.right")
-                            .foregroundColor(.onSurface.opacity(0.4))
+                            .foregroundColor(.onSurface)
                             .font(.system(size: 14, weight: .semibold))
                     }
                 } else {

--- a/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsCard.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsCard.swift
@@ -23,8 +23,8 @@ struct EventDetailsCard: View {
                     .fontWeight(.semibold)
                     .foregroundColor(.onSurface)
                     .fixedSize(horizontal: false, vertical: true)
-                    .padding(.vertical, 7)
-                HStack(spacing: 5) {
+                    .padding(.vertical, Spacing.medium / 2)
+                HStack(spacing: Spacing.extraSmall) {
                     if parentViewModel.notificationsAllowed {
                         if event.from.isAvailableNotificationDate() {
                             NotificationPill(
@@ -46,10 +46,10 @@ struct EventDetailsCard: View {
             }
             Spacer()
         }
-        .padding(10)
+        .padding(Spacing.small)
         .background(event.isSpecial ? Color.red.opacity(0.2) : color.opacity(0.2))
         .cornerRadius(15)
-        .padding(.horizontal, 15)
+        .padding(.horizontal, Spacing.medium)
     }
     
     var notificationEventTitle: String {

--- a/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsCard.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsCard.swift
@@ -16,51 +16,40 @@ struct EventDetailsCard: View {
     let color: Color
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                VStack(alignment: .leading) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 0) {
-                            Text(event.course?.englishName ?? "")
-                                .font(.system(size: 20, weight: .semibold))
-                                .foregroundColor(.onSurface)
-                                .fixedSize(horizontal: false, vertical: true)
-                                .padding(.bottom, 7)
-                            Text(event.title)
-                                .font(.system(size: 18))
-                                .foregroundColor(.onSurface)
+        HStack {
+            VStack(alignment: .leading) {
+                Text(event.title)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.onSurface)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.vertical, 7)
+                HStack(spacing: 5) {
+                    if parentViewModel.notificationsAllowed {
+                        if event.from.isAvailableNotificationDate() {
+                            NotificationPill(
+                                state: $parentViewModel.isNotificationSetForEvent,
+                                title: notificationEventTitle,
+                                image: "bell.badge",
+                                onTap: notificationEventAction
+                            )
                         }
-                        .padding(.bottom, 20)
+                        NotificationPill(
+                            state: $parentViewModel.isNotificationSetForEvent,
+                            title: notificationCourseTitle,
+                            image: "bell.badge",
+                            onTap: notificationCourseAction
+                        )
                     }
-                    VStack(alignment: .leading) {
-                        HStack(spacing: 5) {
-                            if parentViewModel.notificationsAllowed {
-                                if event.from.isAvailableNotificationDate() {
-                                    NotificationPill(
-                                        state: $parentViewModel.isNotificationSetForEvent,
-                                        title: notificationEventTitle,
-                                        image: "bell.badge",
-                                        onTap: notificationEventAction
-                                    )
-                                }
-                                NotificationPill(
-                                    state: $parentViewModel.isNotificationSetForEvent,
-                                    title: notificationCourseTitle,
-                                    image: "bell.badge",
-                                    onTap: notificationCourseAction
-                                )
-                            }
-                            ColorPickerPill(openColorPicker: openColorPicker)
-                        }
-                    }
+                    ColorPickerPill(openColorPicker: openColorPicker)
                 }
-                Spacer()
             }
+            Spacer()
         }
         .padding(10)
         .background(event.isSpecial ? Color.red.opacity(0.2) : color.opacity(0.2))
         .cornerRadius(15)
-        .padding([.horizontal, .bottom], 15)
+        .padding(.horizontal, 15)
     }
     
     var notificationEventTitle: String {

--- a/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsSheet.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/EventDetailsSheet.swift
@@ -14,14 +14,16 @@ struct EventDetailsSheet: View {
     var body: some View {
         VStack {
             ScrollView(showsIndicators: false) {
-                EventDetailsCard(
-                    parentViewModel: viewModel,
-                    openColorPicker: openColorPicker,
-                    event: viewModel.event,
-                    color: viewModel.color
-                )
-                EventDetailsBody(event: viewModel.event)
-                Spacer()
+                VStack(spacing: Spacing.medium) {
+                    EventDetailsCard(
+                        parentViewModel: viewModel,
+                        openColorPicker: openColorPicker,
+                        event: viewModel.event,
+                        color: viewModel.color
+                    )
+                    EventDetailsBody(event: viewModel.event)
+                    Spacer()
+                }
             }
             .background(Color.background)
             .background(
@@ -32,7 +34,7 @@ struct EventDetailsSheet: View {
             )
             .onDisappear(perform: onClose)
         }
-        .padding(.top, 60)
+        .padding(.top, Spacing.header)
         .background(Color.background)
         .overlay(
             CloseCoverButton(onClick: onClose),

--- a/App/Presentation/Views/Bookmarks/EventDetails/EventLocationsView.swift
+++ b/App/Presentation/Views/Bookmarks/EventDetails/EventLocationsView.swift
@@ -41,7 +41,7 @@ struct EventLocationsView: View {
                             schoolColor: viewModel.school!.color
                         )
                         .frame(minHeight: UIScreen.main.bounds.width * 1.33)
-                        .padding(.top, 20)
+                        .padding(.top, Spacing.large)
                     }
                 }
             }
@@ -53,7 +53,7 @@ struct EventLocationsView: View {
             }
         }
         
-        .padding(.top, 55)
+        .padding(.top, Spacing.header)
         .background(Color.background)
         .overlay(
             CloseCoverButton(onClick: close),

--- a/App/Presentation/Views/Bookmarks/List/BookmarkCard.swift
+++ b/App/Presentation/Views/Bookmarks/List/BookmarkCard.swift
@@ -20,6 +20,5 @@ struct BookmarkCard: View {
             VerboseEventButtonLabel(event: event)
         })
         .buttonStyle(ScalingButtonStyle())
-        .padding(.bottom, 10)
     }
 }

--- a/App/Presentation/Views/Bookmarks/List/BookmarkListView.swift
+++ b/App/Presentation/Views/Bookmarks/List/BookmarkListView.swift
@@ -54,13 +54,15 @@ private struct EventList: View {
     let events: RealmSwift.List<Event>
     
     var body: some View {
-        ForEach(events.sorted(by: EventSorting.sortedEventOrder), id: \._id) { event in
-            BookmarkCard(
-                onTapCard: onTapCard,
-                event: event,
-                isLast: event == events.last
-            )
-            .padding(.horizontal, 15)
+        VStack(spacing: Spacing.medium) {
+            ForEach(events.sorted(by: EventSorting.sortedEventOrder), id: \._id) { event in
+                BookmarkCard(
+                    onTapCard: onTapCard,
+                    event: event,
+                    isLast: event == events.last
+                )
+                .padding(.horizontal, Spacing.medium)
+            }
         }
     }
     
@@ -80,7 +82,7 @@ private struct DaysList: View {
                         EventList(events: day.events)
                     })
                 }
-                .padding(.vertical, 15)
+                .padding(.vertical, Spacing.medium)
             }
         }
     }

--- a/App/Presentation/Views/Bookmarks/List/BookmarkListView.swift
+++ b/App/Presentation/Views/Bookmarks/List/BookmarkListView.swift
@@ -28,13 +28,8 @@ struct BookmarkListView: View {
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
-                VStack {
-                    Spacer()
-                        .frame(height: 60)
-                    DaysList(days: days)
-                }
-                .padding(.top, 2.5)
-                .id("bookmarkScrollView")
+                DaysList(days: days)
+                    .id("bookmarkScrollView")
             }
             .overlay(
                 ToTopButton(buttonOffsetX: bookmarksListModel.buttonOffsetX, proxy: proxy),

--- a/App/Presentation/Views/Bookmarks/List/DayHeader.swift
+++ b/App/Presentation/Views/Bookmarks/List/DayHeader.swift
@@ -20,11 +20,11 @@ struct DayHeader: View {
                 .offset(x: 7.5)
                 .frame(height: 1)
                 .cornerRadius(20)
-                .padding(.trailing, 8)
+                .padding(.trailing, Spacing.medium / 2)
             Spacer()
         }
-        .padding(.leading, 15)
-        .padding(.bottom, 7.5)
+        .padding(.leading, Spacing.medium)
+        .padding(.bottom, Spacing.medium / 2)
     }
     
     fileprivate func localizedKey(for inputString: String) -> String {

--- a/App/Presentation/Views/Bookmarks/List/ToTopButton.swift
+++ b/App/Presentation/Views/Bookmarks/List/ToTopButton.swift
@@ -21,11 +21,10 @@ struct ToTopButton: View {
             Image(systemName: "chevron.up")
                 .font(.system(size: 24, weight: .semibold))
                 .foregroundColor(.onPrimary)
-                .padding(20)
+                .padding(12)
         })
         .buttonStyle(ToTopButtonStyle())
-        .padding()
-        .padding(.bottom, 10)
+        .padding(.bottom, 15)
         .offset(x: buttonOffsetX)
     }
 }

--- a/App/Presentation/Views/Bookmarks/List/ToTopButton.swift
+++ b/App/Presentation/Views/Bookmarks/List/ToTopButton.swift
@@ -24,7 +24,7 @@ struct ToTopButton: View {
                 .padding(12)
         })
         .buttonStyle(ToTopButtonStyle())
-        .padding(.bottom, 15)
+        .padding(.bottom, Spacing.medium)
         .offset(x: buttonOffsetX)
     }
 }

--- a/App/Presentation/Views/Bookmarks/ViewSwitcher.swift
+++ b/App/Presentation/Views/Bookmarks/ViewSwitcher.swift
@@ -45,6 +45,7 @@ struct ViewSwitcher: View {
         .frame(width: 280)
         .background(Color.surface)
         .cornerRadius(30)
+        .shadow(radius: 10)
     }
     
     func isSelectedViewType(viewType: ViewType) -> Bool {

--- a/App/Presentation/Views/Bookmarks/Week/BookmarkWeekView.swift
+++ b/App/Presentation/Views/Bookmarks/Week/BookmarkWeekView.swift
@@ -30,7 +30,7 @@ struct BookmarkWeekView: View {
 
             CustomPageControlView(numberOfPages: weekStartDates.count, currentPage: $currentPage)
                 .frame(width: 100, height: 20)
-                .padding(.bottom, 70)
+                .padding(.bottom, 55 + Spacing.medium)
                 .shadow(color: .black.opacity(0.1), radius: 1)
         }
     }

--- a/App/Presentation/Views/Bookmarks/Week/BookmarkWeekView.swift
+++ b/App/Presentation/Views/Bookmarks/Week/BookmarkWeekView.swift
@@ -30,7 +30,8 @@ struct BookmarkWeekView: View {
 
             CustomPageControlView(numberOfPages: weekStartDates.count, currentPage: $currentPage)
                 .frame(width: 100, height: 20)
-                .padding(.bottom, 20)
+                .padding(.bottom, 70)
+                .shadow(color: .black.opacity(0.1), radius: 1)
         }
     }
 }

--- a/App/Presentation/Views/Bookmarks/Week/EmptyEvent.swift
+++ b/App/Presentation/Views/Bookmarks/Week/EmptyEvent.swift
@@ -19,7 +19,7 @@ struct EmptyEvent: View {
                 .foregroundColor(.onSurface)
             Spacer()
         }
-        .padding()
+        .padding(Spacing.card)
         .frame(maxWidth: .infinity, maxHeight: 50)
         .background(Color.surface)
         .cornerRadius(10)

--- a/App/Presentation/Views/Bookmarks/Week/WeekDays.swift
+++ b/App/Presentation/Views/Bookmarks/Week/WeekDays.swift
@@ -26,9 +26,11 @@ struct WeekDays: View {
             },
             content: {
                 if let days = days {
-                    ForEach(days, id: \.self) { day in
-                        ForEach(day.events.sorted(by: EventSorting.sortedEventOrder), id: \.self) { event in
-                            WeekEvent(event: event)
+                    VStack(spacing: 15) {
+                        ForEach(days, id: \.self) { day in
+                            ForEach(day.events.sorted(by: EventSorting.sortedEventOrder), id: \.self) { event in
+                                WeekEvent(event: event)
+                            }
                         }
                     }
                 } else {

--- a/App/Presentation/Views/Bookmarks/Week/WeekDays.swift
+++ b/App/Presentation/Views/Bookmarks/Week/WeekDays.swift
@@ -26,7 +26,7 @@ struct WeekDays: View {
             },
             content: {
                 if let days = days {
-                    VStack(spacing: 15) {
+                    VStack(spacing: Spacing.medium) {
                         ForEach(days, id: \.self) { day in
                             ForEach(day.events.sorted(by: EventSorting.sortedEventOrder), id: \.self) { event in
                                 WeekEvent(event: event)
@@ -38,6 +38,6 @@ struct WeekDays: View {
                 }
             }
         )
-        .padding(.vertical, 10)
+        .padding(.vertical, Spacing.small)
     }
 }

--- a/App/Presentation/Views/Bookmarks/Week/WeekEvent.swift
+++ b/App/Presentation/Views/Bookmarks/Week/WeekEvent.swift
@@ -38,7 +38,7 @@ struct WeekEvent: View {
                         .font(.system(size: 16, weight: .regular))
                         .foregroundColor(.onSurface)
                 }
-                .padding()
+                .padding(Spacing.card)
                 .frame(maxWidth: .infinity, maxHeight: 50)
                 .background(Color.surface)
                 .cornerRadius(10)

--- a/App/Presentation/Views/Bookmarks/Week/WeekPage.swift
+++ b/App/Presentation/Views/Bookmarks/Week/WeekPage.swift
@@ -34,7 +34,7 @@ struct WeekPage: View {
                             .resizable()
                             .scaledToFit()
                             .frame(height: 175)
-                            .padding(.top, 15)
+                            .padding(.top, Spacing.medium)
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
                     .padding(.top, 30)
@@ -48,7 +48,7 @@ struct WeekPage: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-            .padding([.top, .horizontal], 15)
+            .padding([.top, .horizontal], Spacing.medium)
         }
     }
 }

--- a/App/Presentation/Views/Bookmarks/Week/WeekPage.swift
+++ b/App/Presentation/Views/Bookmarks/Week/WeekPage.swift
@@ -15,8 +15,6 @@ struct WeekPage: View {
         let weekOfYear = weekStart.get(.weekOfYear)
 
         ScrollView (showsIndicators: false) {
-            Spacer()
-                .frame(height: 60)
             VStack {
                 HStack {
                     Spacer()

--- a/App/Presentation/Views/Buttons/CompactEventButtonLabel.swift
+++ b/App/Presentation/Views/Buttons/CompactEventButtonLabel.swift
@@ -16,7 +16,6 @@ struct CompactEventButtonLabel: View {
             if let timeFrom = event.from.convertToHoursAndMinutesISOString(),
                let timeTo = event.to.convertToHoursAndMinutesISOString() {
                 HStack {
-                    
                     VStack (alignment: .center, spacing: 0) {
                         Text("\(timeFrom)")
                             .font(.system(size: 13, weight: .semibold))
@@ -78,7 +77,7 @@ struct CompactEventButtonLabel: View {
                     }
                 }
             }
-            .padding()
+            .padding(Spacing.card)
             Spacer()
         }
         .background(event.isSpecial ? Color.red.opacity(0.2) : color.opacity(0.2))

--- a/App/Presentation/Views/General/DraggingPill.swift
+++ b/App/Presentation/Views/General/DraggingPill.swift
@@ -12,7 +12,7 @@ struct DraggingPill: View {
         RoundedRectangle(cornerRadius: 2)
             .fill(Color.gray)
             .frame(width: 40, height: 4)
-            .padding(.top, 10)
+            .padding(.top, Spacing.small)
     }
 }
 

--- a/App/Presentation/Views/General/Info.swift
+++ b/App/Presentation/Views/General/Info.swift
@@ -16,7 +16,7 @@ struct Info: View {
                 Image(systemName: image!)
                     .font(.system(size: 24))
                     .foregroundColor(.onSurface)
-                    .padding(.bottom, 15)
+                    .padding(.bottom, Spacing.medium)
             }
             Text(title)
                 .infoBodyMedium()

--- a/App/Presentation/Views/General/InfoLoading.swift
+++ b/App/Presentation/Views/General/InfoLoading.swift
@@ -12,7 +12,7 @@ struct InfoLoading: View {
     var body: some View {
         VStack(alignment: .center) {
             CustomProgressIndicator()
-                .padding(.bottom, 15)
+                .padding(.bottom, Spacing.medium)
             Text(title)
                 .infoBodyMedium()
                 .multilineTextAlignment(.center)

--- a/App/Presentation/Views/General/SearchField.swift
+++ b/App/Presentation/Views/General/SearchField.swift
@@ -20,7 +20,7 @@ struct SearchField: View {
     @State private var closeButtonOffset: CGFloat = 300.0
     
     var body: some View {
-        HStack {
+        HStack(spacing: 15) {
             TextField(NSLocalizedString(
                 title, comment: ""
             ), text: $searchBarText)
@@ -50,8 +50,6 @@ struct SearchField: View {
                     }
                     .buttonStyle(SearchMenuActionStyle())
                 }
-                .padding(.trailing, 20)
-                .padding(.top, 5)
             }
         }
     }

--- a/App/Presentation/Views/General/SearchField.swift
+++ b/App/Presentation/Views/General/SearchField.swift
@@ -20,7 +20,7 @@ struct SearchField: View {
     @State private var closeButtonOffset: CGFloat = 300.0
     
     var body: some View {
-        HStack(spacing: 15) {
+        HStack(spacing: Spacing.medium) {
             TextField(NSLocalizedString(
                 title, comment: ""
             ), text: $searchBarText)
@@ -34,7 +34,7 @@ struct SearchField: View {
                 .onSubmit(searchAction)
                 .searchBox()
             if searching {
-                HStack (spacing: 15) {
+                HStack (spacing: Spacing.medium) {
                     Button(action: searchAction) {
                         Image(systemName: "magnifyingglass")
                             .foregroundColor(.onPrimary)

--- a/App/Presentation/Views/General/SheetTitle.swift
+++ b/App/Presentation/Views/General/SheetTitle.swift
@@ -17,6 +17,6 @@ struct SheetTitle: View {
                 .sheetTitle()
             Spacer()
         }
-        .padding(.bottom, 15)
+        .padding(.bottom, Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Home/Available/HomeAvailable.swift
+++ b/App/Presentation/Views/Home/Available/HomeAvailable.swift
@@ -13,7 +13,7 @@ struct HomeAvailable: View {
     @Binding var swipedCards: Int
     
     var body: some View {
-        VStack {
+        VStack(spacing: Spacing.extraLarge) {
             TodaysEvents(
                 eventsForToday: $eventsForToday,
                 swipedCards: $swipedCards
@@ -21,6 +21,5 @@ struct HomeAvailable: View {
             NextClass(nextClass: nextClass)
             Spacer()
         }
-        .frame(width: getRect().width - 35)
     }
 }

--- a/App/Presentation/Views/Home/Available/NextClass.swift
+++ b/App/Presentation/Views/Home/Available/NextClass.swift
@@ -11,7 +11,7 @@ struct NextClass: View {
     let nextClass: Event?
     
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
             HStack {
                 if let nextClass = nextClass {
                     Text(nextClass.from.formatDate() ?? "")
@@ -36,6 +36,5 @@ struct NextClass: View {
             }
         }
         .frame(maxWidth: .infinity, minHeight: 100)
-        .padding(.top, 20)
     }
 }

--- a/App/Presentation/Views/Home/Available/TodaysEvents.swift
+++ b/App/Presentation/Views/Home/Available/TodaysEvents.swift
@@ -12,11 +12,11 @@ struct TodaysEvents: View {
     @Binding var swipedCards: Int
     
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: Spacing.medium) {
             Text(NSLocalizedString("Today's events", comment: ""))
                 .font(.system(size: 18, weight: .semibold))
                 .foregroundColor(.onBackground)
-            VStack {
+            VStack(alignment: .center) {
                 if !eventsForToday.isEmpty {
                     TodaysEventsCarousel(
                         swipedCards: $swipedCards,

--- a/App/Presentation/Views/Home/Available/TodaysEventsCarousel.swift
+++ b/App/Presentation/Views/Home/Available/TodaysEventsCarousel.swift
@@ -62,7 +62,7 @@ struct TodaysEventsCarousel: View {
             .cornerRadius(30)
             .buttonStyle(ScalingButtonStyle())
         }
-        .padding(.top, 10)
+        .padding(.top, Spacing.small)
     }
     
     func resetCards() {

--- a/App/Presentation/Views/Home/Home.swift
+++ b/App/Presentation/Views/Home/Home.swift
@@ -43,8 +43,8 @@ struct Home: View {
                 }
                 Spacer()
             }
-            .padding(.horizontal, 15)
-            .padding(.top, 10)
+            .padding(.horizontal, Spacing.medium)
+            .padding(.top, Spacing.small)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color.background)
             .fullScreenCover(

--- a/App/Presentation/Views/Home/HomeNotAvailable.swift
+++ b/App/Presentation/Views/Home/HomeNotAvailable.swift
@@ -10,11 +10,11 @@ import SwiftUI
 struct HomeNotAvailable: View {
     var body: some View {
         VStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: Spacing.large) {
                 Text(NSLocalizedString("Everything looks good for this week", comment: ""))
                     .font(.system(size: 30, weight: .semibold))
                     .foregroundColor(.onBackground)
-                    .padding(.trailing, 10)
+                    .padding(.trailing, Spacing.small)
                 
                 Text(NSLocalizedString("Looks like you don't have any classes or exams in the coming week. Yay!", comment: ""))
                     .font(.system(size: 15, weight: .medium))

--- a/App/Presentation/Views/Home/News/AllNews.swift
+++ b/App/Presentation/Views/Home/News/AllNews.swift
@@ -19,13 +19,13 @@ struct AllNews: View {
                 Spacer()
             }
             if let news = news {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
                     if news.count >= 4 {
                         if news[4...].isEmpty {
                             Text(NSLocalizedString("No other news", comment: ""))
                                 .font(.system(size: 16))
                                 .foregroundColor(.onBackground)
-                                .padding(.top, 7.5)
+                                .padding(.top, Spacing.medium / 2)
                         } else {
                             ForEach(news[4...], id: \.self) { newsItem in
                                 NewsItemCard(newsItem: newsItem)
@@ -35,11 +35,11 @@ struct AllNews: View {
                         Text(NSLocalizedString("No other news", comment: ""))
                             .font(.system(size: 16))
                             .foregroundColor(.onBackground)
-                            .padding(.top, 7.5)
+                            .padding(.top, Spacing.medium / 2)
                     }
                 }
             }
         }
-        .padding(.top, 30)
+        .padding(.top, Spacing.medium * 2)
     }
 }

--- a/App/Presentation/Views/Home/News/News.swift
+++ b/App/Presentation/Views/Home/News/News.swift
@@ -34,7 +34,7 @@ struct News: View {
             })
             .buttonStyle(WideAnimatedButtonStyle())
         }
-        .padding(.bottom, 20)
+        .padding(.bottom, Spacing.large)
         .frame(maxWidth: .infinity)
     }
 }

--- a/App/Presentation/Views/Home/News/NewsItemCard.swift
+++ b/App/Presentation/Views/Home/News/NewsItemCard.swift
@@ -10,29 +10,36 @@ import SwiftUI
 struct NewsItemCard: View {
     let newsItem: Response.NotificationContent
     
+    @State private var detailsSheetOpen = false
+    
     var body: some View {
-        NavigationLink(destination: AnyView(NewsItemDetails(newsItem: newsItem)), label: {
-            VStack(alignment: .leading, spacing: 0) {
-                HStack {
-                    Text(newsItem.title)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(.onSurface)
-                    Spacer()
-                    Text(newsItem.timestamp.formatDate() ?? "")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundColor(.onSurface.opacity(0.8))
-                }
-                .padding(.bottom, 7.5)
-                Text(newsItem.body)
-                    .font(.system(size: 14, weight: .medium))
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(newsItem.title)
+                    .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(.onSurface)
-                    .multilineTextAlignment(.leading)
+                Spacer()
+                Text(newsItem.timestamp.formatDate() ?? "")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(.onSurface.opacity(0.8))
             }
-            .padding(10)
-            .frame(maxWidth: .infinity)
-            .background(Color.surface)
-            .cornerRadius(15)
-            .padding(.vertical, 7.5)
+            .padding(.bottom, 7.5)
+            Text(newsItem.body)
+                .font(.system(size: 14, weight: .medium))
+                .foregroundColor(.onSurface)
+                .multilineTextAlignment(.leading)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity)
+        .background(Color.surface)
+        .cornerRadius(15)
+        .padding(.vertical, 7.5)
+        .onTapGesture {
+            HapticsController.triggerHapticLight()
+            detailsSheetOpen = true
+        }
+        .sheet(isPresented: $detailsSheetOpen, content: {
+            NewsItemDetails(newsItem: newsItem)
         })
     }
 }

--- a/App/Presentation/Views/Home/News/NewsItemCard.swift
+++ b/App/Presentation/Views/Home/News/NewsItemCard.swift
@@ -23,17 +23,16 @@ struct NewsItemCard: View {
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(.onSurface.opacity(0.8))
             }
-            .padding(.bottom, 7.5)
+            .padding(.bottom, Spacing.medium / 2)
             Text(newsItem.body)
                 .font(.system(size: 14, weight: .medium))
                 .foregroundColor(.onSurface)
                 .multilineTextAlignment(.leading)
         }
-        .padding(10)
+        .padding(Spacing.card)
         .frame(maxWidth: .infinity)
         .background(Color.surface)
         .cornerRadius(15)
-        .padding(.vertical, 7.5)
         .onTapGesture {
             HapticsController.triggerHapticLight()
             detailsSheetOpen = true

--- a/App/Presentation/Views/Home/News/NewsItemDetails.swift
+++ b/App/Presentation/Views/Home/News/NewsItemDetails.swift
@@ -9,6 +9,11 @@ import SwiftUI
 
 struct NewsItemDetails: View {
     let newsItem: Response.NotificationContent
+    @Environment(\.dismiss) var dismiss
+    
+    func close() -> Void {
+        dismiss()
+    }
     
     var body: some View {
         ScrollView(showsIndicators: false) {
@@ -33,9 +38,17 @@ struct NewsItemDetails: View {
             .padding(.trailing, 10)
             Spacer()
         }
-        .padding([.horizontal, .top], 15)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .padding(.horizontal, 15)
+        .padding(.top, 55)
         .background(Color.background)
-        .navigationTitle(NSLocalizedString("Details", comment: ""))
+        .overlay(
+            CloseCoverButton(onClick: close),
+            alignment: .topTrailing
+        )
+        .overlay(
+            Text(NSLocalizedString("Details", comment: ""))
+                .sheetTitle(),
+            alignment: .top
+        )
     }
 }

--- a/App/Presentation/Views/Home/News/NewsItemDetails.swift
+++ b/App/Presentation/Views/Home/News/NewsItemDetails.swift
@@ -21,7 +21,7 @@ struct NewsItemDetails: View {
                 Text(newsItem.title)
                     .font(.system(size: 30, weight: .semibold))
                     .foregroundColor(.onBackground)
-                    .padding(.bottom, 20)
+                    .padding(.bottom, Spacing.large)
                 Text(newsItem.timestamp.formatDate() ?? "")
                     .font(.system(size: 20, weight: .medium))
                     .foregroundColor(.onBackground.opacity(0.8))
@@ -30,16 +30,16 @@ struct NewsItemDetails: View {
             VStack(alignment: .leading) {
                 Divider()
                     .opacity(0.8)
-                    .padding(.vertical, 15)
+                    .padding(.vertical, Spacing.medium)
                 Text(newsItem.body)
                     .font(.system(size: 16, weight: .regular))
                     .foregroundColor(.onBackground)
             }
-            .padding(.trailing, 10)
+            .padding(.trailing, Spacing.small)
             Spacer()
         }
-        .padding(.horizontal, 15)
-        .padding(.top, 55)
+        .padding(.horizontal, Spacing.medium)
+        .padding(.top, Spacing.header)
         .background(Color.background)
         .overlay(
             CloseCoverButton(onClick: close),

--- a/App/Presentation/Views/Home/News/NewsSheet.swift
+++ b/App/Presentation/Views/Home/News/NewsSheet.swift
@@ -24,49 +24,41 @@ struct NewsSheet: View {
     }
     
     var body: some View {
-        ZStack {
-            NavigationView {
-                VStack {
-                    SearchField(
-                        search: nil,
-                        clearSearch: nil,
-                        title: "Search news",
-                        searchBarText: $searchText,
-                        searching: $searching,
-                        disabled: .constant(false)
-                    )
-                    .padding(.top, 100)
-                    if !searching {
-                        ScrollView(showsIndicators: false) {
-                            RecentNews(news: news)
-                            AllNews(news: news)
-                        }
-                        .padding([.top, .horizontal], 15)
-                    } else {
-                        ScrollView(showsIndicators: false) {
-                            ForEach(filteredNews, id: \.self) { newsItem in
-                                NewsItemCard(newsItem: newsItem)
-                            }
-                        }
-                        .padding([.top, .horizontal], 15)
+        VStack(spacing: 15) {
+            SearchField(
+                search: nil,
+                clearSearch: nil,
+                title: "Search news",
+                searchBarText: $searchText,
+                searching: $searching,
+                disabled: .constant(false)
+            )
+            if !searching {
+                ScrollView(showsIndicators: false) {
+                    RecentNews(news: news)
+                    AllNews(news: news)
+                }
+            } else {
+                ScrollView(showsIndicators: false) {
+                    ForEach(filteredNews, id: \.self) { newsItem in
+                        NewsItemCard(newsItem: newsItem)
                     }
-                    Spacer()
                 }
-                .edgesIgnoringSafeArea(.all)
-                .frame(maxHeight: .infinity)
-                .background(Color.background)
-                .navigationTitle(NSLocalizedString("News", comment: ""))
-                .navigationBarTitleDisplayMode(.inline)
             }
-            
-            VStack {
-                HStack {
-                    Spacer()
-                    CloseCoverButton(onClick: onClose)
-                }
-                Spacer()
-            }
+            Spacer()
         }
+        .padding(.top, 60)
+        .padding(.horizontal, 15)
+        .background(Color.background)
+        .overlay(
+            CloseCoverButton(onClick: onClose),
+            alignment: .topTrailing
+        )
+        .overlay(
+            Text(NSLocalizedString("News", comment: ""))
+                .sheetTitle(),
+            alignment: .top
+        )
     }
     
     func onClose() {

--- a/App/Presentation/Views/Home/News/NewsSheet.swift
+++ b/App/Presentation/Views/Home/News/NewsSheet.swift
@@ -24,7 +24,7 @@ struct NewsSheet: View {
     }
     
     var body: some View {
-        VStack(spacing: 15) {
+        VStack(spacing: Spacing.medium) {
             SearchField(
                 search: nil,
                 clearSearch: nil,
@@ -47,8 +47,8 @@ struct NewsSheet: View {
             }
             Spacer()
         }
-        .padding(.top, 60)
-        .padding(.horizontal, 15)
+        .padding(.top, Spacing.header)
+        .padding(.horizontal, Spacing.medium)
         .background(Color.background)
         .overlay(
             CloseCoverButton(onClick: onClose),

--- a/App/Presentation/Views/Home/News/RecentNews.swift
+++ b/App/Presentation/Views/Home/News/RecentNews.swift
@@ -33,5 +33,6 @@ struct RecentNews: View {
                 }
             }
         }
+        .padding(.top, 15)
     }
 }

--- a/App/Presentation/Views/Home/News/RecentNews.swift
+++ b/App/Presentation/Views/Home/News/RecentNews.swift
@@ -19,12 +19,12 @@ struct RecentNews: View {
                 Spacer()
             }
             if let news = news {
-                VStack(alignment: .leading) {
+                VStack(alignment: .leading, spacing: Spacing.medium) {
                     if news.isEmpty {
                         Text(NSLocalizedString("No recent news", comment: ""))
                             .font(.system(size: 16))
                             .foregroundColor(.onBackground)
-                            .padding(.top, 7.5)
+                            .padding(.top, Spacing.medium / 2)
                     } else {
                         ForEach(news.pick(length: 4), id: \.self) { newsItem in
                             NewsItemCard(newsItem: newsItem)
@@ -33,6 +33,6 @@ struct RecentNews: View {
                 }
             }
         }
-        .padding(.top, 15)
+        .padding(.top, Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Popup/PopupToast.swift
+++ b/App/Presentation/Views/Popup/PopupToast.swift
@@ -33,7 +33,7 @@ struct PopupToast: BottomPopup {
         .frame(maxWidth: .infinity, minHeight: 50)
         .background(Color.primary)
         .cornerRadius(10.0)
-        .padding(15)
+        .padding(Spacing.medium)
         .padding(.bottom, 40)
     }
     

--- a/App/Presentation/Views/Search/Preview/BookmarkButton.swift
+++ b/App/Presentation/Views/Search/Preview/BookmarkButton.swift
@@ -24,7 +24,7 @@ struct BookmarkButton: View {
                 case .loading, .disabled:
                     CustomProgressIndicator(color: .onPrimary)
                 case .saved:
-                    HStack(spacing: 10) {
+                    HStack(spacing: Spacing.small) {
                         Image(systemName: "bookmark.fill")
                             .font(.system(size: 16))
                             .foregroundColor(.onPrimary)
@@ -33,7 +33,7 @@ struct BookmarkButton: View {
                             .foregroundColor(.onPrimary)
                     }
                 case .notSaved:
-                    HStack(spacing: 10) {
+                    HStack(spacing: Spacing.small) {
                         Image(systemName: "bookmark")
                             .font(.system(size: 16))
                             .foregroundColor(.onPrimary)
@@ -45,6 +45,6 @@ struct BookmarkButton: View {
             }
         }
         .buttonStyle(PillStyle(color: .primary))
-        .padding()
+        .padding(Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Search/Preview/DayResponseHeader.swift
+++ b/App/Presentation/Views/Search/Preview/DayResponseHeader.swift
@@ -22,7 +22,7 @@ struct DayResponseHeader: View {
                 .cornerRadius(20)
             Spacer()
         }
-        .padding(.bottom, 7.5)
+        .padding(.bottom, Spacing.medium / 2)
     }
     
     fileprivate func localizedKey(for inputString: String) -> String {

--- a/App/Presentation/Views/Search/Preview/SearchPreviewList.swift
+++ b/App/Presentation/Views/Search/Preview/SearchPreviewList.swift
@@ -20,24 +20,25 @@ struct SearchPreviewList: View {
     
     var body: some View {
         ScrollView(showsIndicators: false) {
-            VStack(spacing: 10) {
+            VStack(spacing: Spacing.small) {
                 ForEach(createDays() ?? [], id: \.id) { day in
                     if !day.events.isEmpty {
                         VStack {
                             DayResponseHeader(day: day)
-                            ForEach(day.events, id: \.id) { event in
-                                VerboseEventResponseButtonLabel(
-                                    event: event,
-                                    color: viewModel.courseColorsForPreview[event.course.id]?.toColor() ?? .white
-                                )
-                                .padding(.bottom, 10)
+                            VStack(spacing: Spacing.medium) {
+                                ForEach(day.events, id: \.id) { event in
+                                    VerboseEventResponseButtonLabel(
+                                        event: event,
+                                        color: viewModel.courseColorsForPreview[event.course.id]?.toColor() ?? .white
+                                    )
+                                }
                             }
                         }
-                        .padding(.vertical, 20)
+                        .padding(.vertical, Spacing.large)
                     }
                 }
             }
-            .padding(.horizontal, 15)
+            .padding(.horizontal, Spacing.medium)
         }
     }
     

--- a/App/Presentation/Views/Search/Preview/SearchPreviewSheet.swift
+++ b/App/Presentation/Views/Search/Preview/SearchPreviewSheet.swift
@@ -24,7 +24,7 @@ struct SearchPreviewSheet: View {
                 SearchPreviewList(
                     viewModel: viewModel
                 )
-                .padding(.top, 60)
+                .padding(.top, Spacing.header)
             case .loading:
                 CustomProgressIndicator()
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)

--- a/App/Presentation/Views/Search/SchoolPill.swift
+++ b/App/Presentation/Views/Search/SchoolPill.swift
@@ -50,7 +50,7 @@ struct SchoolPill: View, Pill {
             .padding(2)
         })
         .buttonStyle(PillStyle(color: isSelected() ? .primary : .surface))
-        .padding(5)
+        .padding(Spacing.extraSmall)
     }
     
     var fontSize: CGFloat {

--- a/App/Presentation/Views/Search/Search.swift
+++ b/App/Presentation/Views/Search/Search.swift
@@ -13,10 +13,11 @@ struct Search: View {
         
     var body: some View {
         NavigationView {
-            VStack(spacing: 0) {
+            VStack(spacing: 15) {
                 switch viewModel.status {
                 case .initial:
                     SearchInfo(schools: viewModel.schools, selectedSchool: $viewModel.selectedSchool)
+                        .padding(.bottom, 15)
                 case .loading:
                     CustomProgressIndicator()
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
@@ -42,7 +43,6 @@ struct Search: View {
                     disabled: $viewModel.schoolNotSelected
                 )
                 .blur(radius: viewModel.schoolNotSelected ? 2.5 : 0)
-                .padding(.bottom, 15)
             }
             .background(Color.background)
             .onChange(of: viewModel.selectedSchool) { school in
@@ -61,6 +61,7 @@ struct Search: View {
                 )
                 .background(Color.background)
             }
+            .padding([.horizontal, .bottom], 15)
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle(NSLocalizedString("Search", comment: ""))
         }

--- a/App/Presentation/Views/Search/Search.swift
+++ b/App/Presentation/Views/Search/Search.swift
@@ -13,11 +13,11 @@ struct Search: View {
         
     var body: some View {
         NavigationView {
-            VStack(spacing: 15) {
+            VStack(spacing: Spacing.medium) {
                 switch viewModel.status {
                 case .initial:
                     SearchInfo(schools: viewModel.schools, selectedSchool: $viewModel.selectedSchool)
-                        .padding(.bottom, 15)
+                        .padding(.bottom, Spacing.medium)
                 case .loading:
                     CustomProgressIndicator()
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
@@ -61,7 +61,7 @@ struct Search: View {
                 )
                 .background(Color.background)
             }
-            .padding([.horizontal, .bottom], 15)
+            .padding([.horizontal, .bottom], Spacing.medium)
             .navigationBarTitleDisplayMode(.inline)
             .navigationTitle(NSLocalizedString("Search", comment: ""))
         }

--- a/App/Presentation/Views/Search/SearchError.swift
+++ b/App/Presentation/Views/Search/SearchError.swift
@@ -13,15 +13,15 @@ struct SearchError: View {
             Spacer()
             Image(systemName: "wifi.exclamationmark")
                 .font(.system(size: 24))
-                .padding(.bottom, 20)
+                .padding(.bottom, Spacing.large)
             Text(NSLocalizedString("Looks like something went wrong", comment: ""))
                 .font(.headline)
                 .foregroundColor(.onBackground)
-                .padding(.bottom, 25)
+                .padding(.bottom, Spacing.extraLarge)
             Spacer()
         }
-        .padding(.bottom, 10)
-        .padding(.leading, 15)
-        .padding(.trailing, 15)
+        .padding(.bottom, Spacing.small)
+        .padding(.leading, Spacing.medium)
+        .padding(.trailing, Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Search/SearchInfo.swift
+++ b/App/Presentation/Views/Search/SearchInfo.swift
@@ -47,6 +47,5 @@ struct SearchInfo: View {
                 }
             }
         }
-        .padding()
     }
 }

--- a/App/Presentation/Views/Search/SearchInfo.swift
+++ b/App/Presentation/Views/Search/SearchInfo.swift
@@ -21,7 +21,7 @@ struct SearchInfo: View {
                 ))
                 .infoHeaderSmall()
                 .multilineTextAlignment(.leading)
-                .padding(.bottom, 10)
+                .padding(.bottom, Spacing.small)
             }
             
             FlowStack(items: schools, viewGenerator: { school in

--- a/App/Presentation/Views/Search/SearchResults.swift
+++ b/App/Presentation/Views/Search/SearchResults.swift
@@ -23,7 +23,7 @@ struct SearchResults: View {
                 Spacer()
             }
             ScrollView(showsIndicators: false) {
-                LazyVStack {
+                LazyVStack(spacing: 15) {
                     ForEach(searchResults, id: \.id) { programme in
                         ProgrammeCard(
                             programme: programme,
@@ -34,6 +34,7 @@ struct SearchResults: View {
                 }
             }
             .background(Color.background)
+            .cornerRadius(10)
         }
     }
 }

--- a/App/Presentation/Views/Search/SearchResults.swift
+++ b/App/Presentation/Views/Search/SearchResults.swift
@@ -23,7 +23,7 @@ struct SearchResults: View {
                 Spacer()
             }
             ScrollView(showsIndicators: false) {
-                LazyVStack(spacing: 15) {
+                LazyVStack(spacing: Spacing.medium) {
                     ForEach(searchResults, id: \.id) { programme in
                         ProgrammeCard(
                             programme: programme,

--- a/App/Presentation/Views/Settings/Appearance/AppearanceSettings.swift
+++ b/App/Presentation/Views/Settings/Appearance/AppearanceSettings.swift
@@ -30,7 +30,6 @@ struct AppearanceSettings: View {
                     }
                 }
             }
-            .padding(.top, 20)
         }
     }
 }

--- a/App/Presentation/Views/Settings/Bookmarks/BookmarksSettingsRow.swift
+++ b/App/Presentation/Views/Settings/Bookmarks/BookmarksSettingsRow.swift
@@ -27,7 +27,7 @@ struct BookmarkSettingsRow: View {
                     WidgetCenter.shared.reloadAllTimelines()
                 }
             }
-            .padding(10)
+            .padding(Spacing.small)
             .frame(maxWidth: .infinity)
             .background(Color.surface)
             .cornerRadius(10)
@@ -39,6 +39,6 @@ struct BookmarkSettingsRow: View {
             .background(Color.red)
         }
         .swipeActionCornerRadius(5)
-        .padding(15)
+        .padding(Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Settings/Buttons/SettingsExternalButton.swift
+++ b/App/Presentation/Views/Settings/Buttons/SettingsExternalButton.swift
@@ -50,13 +50,13 @@ struct SettingsExternalButton: View {
                     Text(current)
                         .font(.system(size: 18, weight: .regular))
                         .foregroundColor(.onSurface.opacity(0.4))
-                        .padding(.trailing, 10)
+                        .padding(.trailing, Spacing.medium)
                 }
                 Image(systemName: trailingIcon)
                     .font(.system(size: 15, weight: .medium))
                     .foregroundColor(.onSurface.opacity(0.4))
             }
         })
-        .padding(10)
+        .padding(Spacing.settingsButton)
     }
 }

--- a/App/Presentation/Views/Settings/Buttons/SettingsNavigationButton.swift
+++ b/App/Presentation/Views/Settings/Buttons/SettingsNavigationButton.swift
@@ -42,13 +42,13 @@ struct SettingsNavigationButton: View {
                     Text(current)
                         .font(.system(size: 18, weight: .regular))
                         .foregroundColor(.onSurface.opacity(0.4))
-                        .padding(.trailing, 10)
+                        .padding(.trailing, Spacing.medium)
                 }
                 Image(systemName: "chevron.right")
                     .foregroundColor(.onSurface.opacity(0.4))
                     .font(.system(size: 14, weight: .semibold))
             }
-            .padding(10)
+            .padding(Spacing.settingsButton)
         })
     }
 }

--- a/App/Presentation/Views/Settings/Buttons/SettingsNavigationButton.swift
+++ b/App/Presentation/Views/Settings/Buttons/SettingsNavigationButton.swift
@@ -29,7 +29,11 @@ struct SettingsNavigationButton: View {
     }
     
     var body: some View {
-        NavigationLink(destination: destination, label: {
+        NavigationLink(destination: {
+            destination
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+        }, label: {
             HStack {
                 Label(title, systemImage: leadingIcon)
                     .labelStyle(ColorfulIconLabelStyle(color: leadingIconBackgroundColor))

--- a/App/Presentation/Views/Settings/List/SettingsListGroup.swift
+++ b/App/Presentation/Views/Settings/List/SettingsListGroup.swift
@@ -18,10 +18,10 @@ struct SettingsListGroup<Content: View>: View {
         VStack {
             content()
         }
-        .padding(10)
+        .padding(Spacing.small)
         .frame(maxWidth: .infinity)
         .background(Color.surface)
         .cornerRadius(10)
-        .padding([.horizontal, .vertical], 15)
+        .padding([.horizontal, .vertical], Spacing.medium)
     }
 }

--- a/App/Presentation/Views/Settings/Settings.swift
+++ b/App/Presentation/Views/Settings/Settings.swift
@@ -23,94 +23,90 @@ struct Settings: View {
     @State private var showShareSheet: Bool = false
     
     var body: some View {
-        VStack {
-            SettingsList {
-                SettingsListGroup {
-                    SettingsNavigationButton(
-                        title: NSLocalizedString("Appearance", comment: ""),
-                        current: NSLocalizedString($appearance.wrappedValue, comment: ""),
-                        leadingIcon: "moon",
-                        leadingIconBackgroundColor: .purple,
-                        destination: AnyView(AppearanceSettings(appearance: $appearance))
-                    )
-                    Divider()
-                    SettingsExternalButton(
-                        title: NSLocalizedString("App language", comment: ""),
-                        current: currentLocale != nil ? LanguageTypes.fromLocaleName(currentLocale!)?.displayName : nil,
-                        leadingIcon: "globe",
-                        leadingIconBackgroundColor: .blue,
-                        action: {
-                            if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
-                                UIApplication.shared.open(settingsURL)
-                            }
+        SettingsList {
+            SettingsListGroup {
+                SettingsNavigationButton(
+                    title: NSLocalizedString("Appearance", comment: ""),
+                    current: NSLocalizedString($appearance.wrappedValue, comment: ""),
+                    leadingIcon: "moon",
+                    leadingIconBackgroundColor: .purple,
+                    destination: AnyView(AppearanceSettings(appearance: $appearance))
+                )
+                Divider()
+                SettingsExternalButton(
+                    title: NSLocalizedString("App language", comment: ""),
+                    current: currentLocale != nil ? LanguageTypes.fromLocaleName(currentLocale!)?.displayName : nil,
+                    leadingIcon: "globe",
+                    leadingIconBackgroundColor: .blue,
+                    action: {
+                        if let settingsURL = URL(string: UIApplication.openSettingsURLString) {
+                            UIApplication.shared.open(settingsURL)
                         }
-                    )
-                }
-                SettingsListGroup {
-                    SettingsNavigationButton(
-                        title: NSLocalizedString("Notification offset", comment: ""),
-                        leadingIcon: "clock",
-                        leadingIconBackgroundColor: .red,
-                        destination: AnyView(NotificationOffsetSettings(
-                            offset: $offset,
-                            rescheduleNotifications: rescheduleNotifications
-                        ))
-                    )
-                    Divider()
-                    SettingsNavigationButton(
-                        title: NSLocalizedString("Bookmarks", comment: ""),
-                        leadingIcon: "bookmark",
-                        leadingIconBackgroundColor: .primary,
-                        destination: AnyView(BookmarksSettings(
-                            parentViewModel: viewModel
-                        ))
-                    )
-                }
-                SettingsListGroup {
-                    SettingsExternalButton(
-                        title: NSLocalizedString("Review the app", comment: ""),
-                        leadingIcon: "star.leadinghalf.filled",
-                        leadingIconBackgroundColor: .yellow,
-                        action: UIApplication.shared.openAppStoreForReview
-                    )
-                    Divider()
-                    SettingsExternalButton(
-                        title: NSLocalizedString("Share feedback", comment: ""),
-                        leadingIcon: "envelope",
-                        leadingIconBackgroundColor: .blue,
-                        action: UIApplication.shared.shareFeedback
-                    )
-                    Divider()
-                    SettingsExternalButton(
-                        title: NSLocalizedString("Share the app", comment: ""),
-                        leadingIcon: "square.and.arrow.up",
-                        leadingIconBackgroundColor: .green,
-                        action: {
-                            showShareSheet = true
-                    })
-                }
-                SettingsListGroup {
-                    SettingsExternalButton(
-                        title: NSLocalizedString("Tumble on GitHub", comment: ""),
-                        leadingIcon: "chevron.left.forwardslash.chevron.right",
-                        leadingIconBackgroundColor: .black,
-                        action: UIApplication.shared.openSourceCode)
-                }
-                
-                if let appVersion = appVersion {
-                    Text("Tumble, iOS v.\(appVersion)")
-                        .font(.system(size: 12, weight: .regular))
-                        .foregroundColor(.onBackground.opacity(0.7))
-                        .padding(35)
-                }
+                    }
+                )
             }
-            .padding(.top, 20)
-            .background(Color.background)
-            .sheet(isPresented: $showShareSheet, content: {
-                ShareSheet()
-            })
+            SettingsListGroup {
+                SettingsNavigationButton(
+                    title: NSLocalizedString("Notification offset", comment: ""),
+                    leadingIcon: "clock",
+                    leadingIconBackgroundColor: .red,
+                    destination: AnyView(NotificationOffsetSettings(
+                        offset: $offset,
+                        rescheduleNotifications: rescheduleNotifications
+                    ))
+                )
+                Divider()
+                SettingsNavigationButton(
+                    title: NSLocalizedString("Bookmarks", comment: ""),
+                    leadingIcon: "bookmark",
+                    leadingIconBackgroundColor: .primary,
+                    destination: AnyView(BookmarksSettings(
+                        parentViewModel: viewModel
+                    ))
+                )
+            }
+            SettingsListGroup {
+                SettingsExternalButton(
+                    title: NSLocalizedString("Review the app", comment: ""),
+                    leadingIcon: "star.leadinghalf.filled",
+                    leadingIconBackgroundColor: .yellow,
+                    action: UIApplication.shared.openAppStoreForReview
+                )
+                Divider()
+                SettingsExternalButton(
+                    title: NSLocalizedString("Share feedback", comment: ""),
+                    leadingIcon: "envelope",
+                    leadingIconBackgroundColor: .blue,
+                    action: UIApplication.shared.shareFeedback
+                )
+                Divider()
+                SettingsExternalButton(
+                    title: NSLocalizedString("Share the app", comment: ""),
+                    leadingIcon: "square.and.arrow.up",
+                    leadingIconBackgroundColor: .green,
+                    action: {
+                        showShareSheet = true
+                    }
+                )
+            }
+            SettingsListGroup {
+                SettingsExternalButton(
+                    title: NSLocalizedString("Tumble on GitHub", comment: ""),
+                    leadingIcon: "chevron.left.forwardslash.chevron.right",
+                    leadingIconBackgroundColor: .black,
+                    action: UIApplication.shared.openSourceCode
+                )
+            }
+            if let appVersion = appVersion {
+                Text("Tumble, iOS v.\(appVersion)")
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundColor(.onBackground.opacity(0.7))
+                    .padding(35)
+            }
         }
-        .background(Color.background)
+        .sheet(isPresented: $showShareSheet, content: {
+            ShareSheet()
+        })
         .navigationTitle(NSLocalizedString("Settings", comment: ""))
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/App/Presentation/Views/Settings/ShareSheet.swift
+++ b/App/Presentation/Views/Settings/ShareSheet.swift
@@ -31,7 +31,7 @@ struct ShareSheet: View {
                     Text(NSLocalizedString("Scan QR Code", comment: ""))
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.onSurface)
-                        .padding(.bottom, 7)
+                        .padding(.bottom, Spacing.medium / 2)
                     if let qrCodeImage = qrCodeImage {
                         Image(uiImage: qrCodeImage)
                             .interpolation(.none)
@@ -49,7 +49,7 @@ struct ShareSheet: View {
                 .overlay(RoundedRectangle(cornerRadius: 10)
                     .stroke(Color.onSurface.opacity(0.5), lineWidth: 2))
             }
-            .padding(.top, 20)
+            .padding(.top, Spacing.large)
             Spacer()
         }
         .overlay(
@@ -73,7 +73,7 @@ struct ShareSheet: View {
                     Text(NSLocalizedString("Copy link", comment: ""))
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundColor(.onSurface)
-                        .padding(.bottom, 7)
+                        .padding(.bottom, Spacing.medium / 2)
                     Text(websiteLink)
                         .font(.system(size: 12))
                         .foregroundColor(.onSurface.opacity(0.7))

--- a/App/Resources/Spacings.swift
+++ b/App/Resources/Spacings.swift
@@ -1,0 +1,26 @@
+//
+//  Spacings.swift
+//  App
+//
+//  Created by Timur Ramazanov on 04.10.2024.
+//
+
+import Foundation
+
+struct Spacing {
+    /// For VStack/HStack spacing and padding
+    static let extraSmall: CGFloat = 5
+    static let small: CGFloat = 10
+    static let medium: CGFloat = 15
+    static let large: CGFloat = 20
+    static let extraLarge: CGFloat = 35
+    
+    /// Custom header
+    static let header: CGFloat = 55
+    
+    /// Inner padding for cards (Details, Event, Resource)
+    static let card: CGFloat = 15
+    
+    /// Inner padding for settings buttons
+    static let settingsButton: CGFloat = 10
+}

--- a/Assets/ru.lproj/Localizable.strings
+++ b/Assets/ru.lproj/Localizable.strings
@@ -452,7 +452,7 @@
 
 "Set custom colors for the courses in your schedules. Just press an event and modify the color to your liking."="Установите индивидуальные цвета для курсов в своих расписаниях. Просто нажмите на событие и измените цвет по своему вкусу.";
 
-"Booking"="Брониванние";
+"Booking"="Бронивание";
 
 "Log in to your KronoX account and book resources and exams. Booking is easy, and notifications remind you to confirm the bookings you've created."="Войдите в свою учетную запись Kronox и забронируйте ресурсы и экзамены. Бронирование осуществляется легко, а уведомления напоминают вам о необходимости подтвердить созданные вами бронирования.";
 

--- a/Tumble.xcodeproj/project.pbxproj
+++ b/Tumble.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C6049E62CAFEA0400E110C4 /* Spacings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C6049E52CAFEA0400E110C4 /* Spacings.swift */; };
 		1CB1962E2CA5F78600B747BF /* EventLocationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB1962D2CA5F78600B747BF /* EventLocationsView.swift */; };
 		1CB196312CA600FE00B747BF /* SwiftSVG in Frameworks */ = {isa = PBXBuildFile; productRef = 1CB196302CA600FE00B747BF /* SwiftSVG */; };
 		1CB196342CA743C500B747BF /* CampusMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CB196332CA743C500B747BF /* CampusMapView.swift */; };
@@ -323,6 +324,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C6049E52CAFEA0400E110C4 /* Spacings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacings.swift; sourceTree = "<group>"; };
 		1CB1962C2CA598A300B747BF /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1CB1962D2CA5F78600B747BF /* EventLocationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLocationsView.swift; sourceTree = "<group>"; };
 		1CB196332CA743C500B747BF /* CampusMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CampusMapView.swift; sourceTree = "<group>"; };
@@ -1173,6 +1175,7 @@
 			children = (
 				D4BAE61829246AA200143717 /* Schools.json */,
 				D48F0D8929367CAF0039CD0F /* Colors.swift */,
+				1C6049E52CAFEA0400E110C4 /* Spacings.swift */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -1828,6 +1831,7 @@
 				D4FFCC2229EDA9E200708CC0 /* Schedule.swift in Sources */,
 				D4E83EB8299959AF002E5F88 /* LoginButton.swift in Sources */,
 				D4A550D52994755900028BCF /* BookmarkButton.swift in Sources */,
+				1C6049E62CAFEA0400E110C4 /* Spacings.swift in Sources */,
 				D423F6AE29F0085D00C04123 /* SchoolPill.swift in Sources */,
 				D454DECE29D3B900005BDAE3 /* BookmarksSettings.swift in Sources */,
 				D4A433BA29952A8A00BFEB7A /* EventExtension.swift in Sources */,


### PR DESCRIPTION
The main goal of these changes was to keep consistency and use 15pt paddings and spacings

![Simulator Screenshot - iPhone 15 Pro - 2024-10-04 at 08 44 11](https://github.com/user-attachments/assets/984abcc5-5eae-4c3e-8552-d115aa4bd7ea)
comment: padding before and after the divider as well as the spacing between the timeslot elements is the same which makes the overall layout more clean and straight

![Simulator Screenshot - iPhone 15 Pro - 2024-10-03 at 23 18 08](https://github.com/user-attachments/assets/715990b8-c875-4050-bd82-54c95af46dd5)
comment: removed the divider horizontal padding to make it look like extended header, the same was done in resource date selector and time selector. Adjusted the resources padding so that the related elements are grouped closer.
